### PR TITLE
Get extra commit info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,5 +81,5 @@ all: jsoncdc.so
 
 .PHONY: test
 test:
-	pgxn check ./
+	pgxn check -U postgres ./
 	util/checkstyle

--- a/build.rs
+++ b/build.rs
@@ -2,14 +2,12 @@ extern crate cc;
 
 use std::process::Command;
 
-
 #[derive(Default)]
 struct PGConfig {
     includedir: String,
     includedir_server: String,
     libdir: String,
 }
-
 
 fn pg_config() -> PGConfig {
     let output = Command::new("pg_config").output().unwrap_or_else(|e| {
@@ -26,9 +24,7 @@ fn pg_config() -> PGConfig {
 
     let mut config = PGConfig { ..Default::default() };
 
-    let text = String::from_utf8(output.stdout).expect(
-        "Expected UTF-8 from call to `pg_config`.",
-    );
+    let text = String::from_utf8(output.stdout).expect("Expected UTF-8 from call to `pg_config`.");
 
     for words in text.lines().map(|line| line.split_whitespace()) {
         let vec: Vec<&str> = words.collect();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 ideal_width            = 79
-max_width              = 79
+max_width              = 100
 
 fn_single_line         = true
 struct_lit_width       = 50


### PR DESCRIPTION
This merge brings us up to latest master of jsoncdc.

This already includes the changes we have for 9.6 support with messages

Additionally, this adds one extra commit which adds some fields we want for messages, which includes the epoch to allow us to handle xid rollover more sanely, as well as xmin and catalog_xmin which gives us a better idea of progress in the stream.

This allows us to use the xmin to try and find any missing rows in the event of a db failover.
